### PR TITLE
Impl Kafka gato and fix ExampleGato + HertaGato eff boost

### DIFF
--- a/gato/gatos/ExampleGato.py
+++ b/gato/gatos/ExampleGato.py
@@ -17,7 +17,6 @@ class ExampleGato(ABaseGato):
     VALUES_TO_SAVE = ABaseGato.VALUES_TO_SAVE + [
         "buff_duration",
         "buff_cooldown",
-        "has_buff",
         "find_object_cooldown"
     ]
 
@@ -34,23 +33,24 @@ class ExampleGato(ABaseGato):
     @require_alive
     def efficiency_buff(self, seconds):
         # Update buff duration and cooldown
-        self.buff_duration -= seconds
-        self.buff_cooldown -= seconds
+        if self.buff_duration > 0:
+            self.buff_duration = max(self.buff_duration - seconds, 0)
+        if self.buff_cooldown > 0:
+            self.buff_cooldown = max(self.buff_cooldown - seconds, 0)
+
+        # Remove boost and return if duration ran out and still in cooldown
+        if self.buff_duration <= 0 and self.buff_cooldown > 0:
+            self.efficiency_boosts.pop(self.BUFF_KEY, None)
+            return
 
         # Apply buff if cooldown is over
-        if self.buff_cooldown <= 0 or self.buff_duration > 0:
-            # Increase efficiency boost
-            self.efficiency_boosts[self.BUFF_KEY] = 20/100 + (2/100 * self.eidolon)
-
+        if self.buff_cooldown <= 0:
             # Set base cooldown and duration
-            self.buff_duration += 20*60
-            self.buff_cooldown += 60*60
-            self.has_buff = True
+            self.buff_duration = 20*60
+            self.buff_cooldown = 60*60
 
-        # Remove buff if duration is over
-        if self.buff_duration <= 0 and self.has_buff:
-            self.efficiency_boosts.pop(self.BUFF_KEY)
-            self.has_buff = False
+        # Apply efficiency boost
+        self.efficiency_boosts[self.BUFF_KEY] = 20/100 + (2/100 * self.eidolon)
 
 
     def random_object(self, seconds):

--- a/gato/gatos/HertaGato.py
+++ b/gato/gatos/HertaGato.py
@@ -1,7 +1,3 @@
-from collections import Counter
-from enum import Enum
-import random
-
 from ABaseGato import ABaseGato, require_alive
 
 
@@ -20,7 +16,6 @@ class HertaGato(ABaseGato):
     VALUES_TO_SAVE = ABaseGato.VALUES_TO_SAVE + [
         "buff_duration",
         "buff_cooldown",
-        "has_buff",
     ]
 
     HERTA_EVENT_TYPE_KURU_KURU = "herta_kuru_kuru"
@@ -36,25 +31,28 @@ class HertaGato(ABaseGato):
     @require_alive
     def efficiency_buff(self, seconds):
         # Update buff duration and cooldown
-        self.buff_duration -= seconds
-        self.buff_cooldown -= seconds
+        if self.buff_duration > 0:
+            self.buff_duration = max(self.buff_duration - seconds, 0)
+        if self.buff_cooldown > 0:
+            self.buff_cooldown = max(self.buff_cooldown - seconds, 0)
 
-        # Apply buff if cooldown is over
-        if self.buff_cooldown <= 0 or self.buff_duration > 0:
-            # Apply efficiency boost
-            eidolon_buff_increase = 0.02 * min(self.eidolon, 5)
-            self.efficiency_boosts[self.BUFF_KEY] = 0.2 + eidolon_buff_increase
+        # Remove boost and return if duration ran out and still in cooldown
+        if self.buff_duration <= 0 and self.buff_cooldown > 0:
+            self.efficiency_boosts.pop(self.BUFF_KEY, None)
+            return
 
+        # Activate the buff if cd is clear
+        if self.buff_cooldown <= 0:
             # Set base cooldown and duration
-            self.buff_duration += 20*60 if self.eidolon < 6 else 30*60
-            self.buff_cooldown += 60*60
+            self.buff_duration = 1200 if self.eidolon < 6 else 1800
+            self.buff_cooldown = 3600
 
             # Fire event
             self._events.append({self.HERTA_EVENT_TYPE_KURU_KURU: None})
 
-        # Remove buff if duration is over
-        if self.buff_duration <= 0 and self.has_buff:
-            self.efficiency_boosts.pop(self.BUFF_KEY)
+        # Apply efficiency boost
+        eidolon_buff_increase = 0.02 * min(self.eidolon, 5)
+        self.efficiency_boosts[self.BUFF_KEY] = 0.2 + eidolon_buff_increase
 
     def simulate(self, team: list["ABaseGato"], seconds: int = 1):
         # We calculate its efficiency boost before its actions

--- a/gato/gatos/KafkaGato.py
+++ b/gato/gatos/KafkaGato.py
@@ -1,0 +1,62 @@
+from ABaseGato import ABaseGato, require_alive
+
+
+class KafkaGato(ABaseGato):
+    """
+        > Fav Food: Red Bull
+        > Increases all allies’ efficiency by 10% for 20 minutes after every hour.
+        > Eidolons: e1->e5 (increases efficiency boost by 1%)
+        > E6: (increases time to 22 minutes).
+    """
+
+    # TODO: image & animation
+    IMAGE = "https://cdn.discordapp.com/attachments/1198010808672723075/1201435790845165658/nuxiom_gato.PNG"
+    ANIMATIONS = "kafkagato"
+    DISPLAY_NAME = "Shader Cat"
+    RARITY = 4
+    VALUES_TO_SAVE: list[str] = ABaseGato.VALUES_TO_SAVE + [
+        'eff_boost_duration',
+        'eff_boost_cooldown',
+    ]
+
+    KAFKA_EFF_BOOST_EVENT_TYPE: str = "kafka_eff_boost"
+    EVENT_DESCRIPTIONS: dict[str, str] = ABaseGato.EVENT_DESCRIPTIONS | {
+        KAFKA_EFF_BOOST_EVENT_TYPE: "boosted efficiency of all allies!",
+    }
+    KAFKA_EFF_BOOST_KEY: str = "kafka_eff_boost"
+
+    eff_boost_duration: int = 0
+    eff_boost_cooldown: int = 0
+
+    @require_alive
+    def maybe_apply_eff_boost(self, team, seconds):
+        # Update boost duration and cooldown
+        if self.eff_boost_duration > 0:
+            self.eff_boost_duration = max(self.eff_boost_duration - seconds, 0)
+        if self.eff_boost_cooldown > 0:
+            self.eff_boost_cooldown = max(self.eff_boost_cooldown - seconds, 0)
+
+        # Remove boost and return if duration ran out and still in cooldown
+        if self.eff_boost_duration <= 0 and self.eff_boost_cooldown > 0:
+            for g in team:
+                g.efficiency_boosts.pop(self.KAFKA_EFF_BOOST_KEY, None)
+            return
+
+        # Activate the boost if cd is clear
+        if self.eff_boost_cooldown <= 0:
+            # Refresh full boost duration and cooldown
+            self.eff_boost_duration = 1200 if self.eidolon < 6 else 1320
+            self.eff_boost_cooldown = 3600
+            # Fire event
+            self._events.append({self.KAFKA_EFF_BOOST_EVENT_TYPE: None})
+
+        # Apply efficiency boost
+        boost_amount = 0.1 + 0.01 * min(self.eidolon, 5)
+        for g in team:
+            g.efficiency_boosts[self.KAFKA_EFF_BOOST_KEY] = boost_amount
+
+    def simulate(self, team: list["ABaseGato"], seconds: int = 1):
+        # Check and apply efficiency boost if applicable
+        self.maybe_apply_eff_boost(team, seconds)
+
+        return super().simulate(team, seconds)


### PR DESCRIPTION
Add kafka and also fix an eff boost duration calculation bug shared by ExampleGato and HertaGato. 

> once their eff buff kicks in for the first time, it never expires. 
> Since we essentially have a 
> ```python
> if buff_duration > 0:
>   buff_duration += 1200
> ```
> situation.